### PR TITLE
Removes conflicting tags and variables from TagManager plugin,#PG-4058

### DIFF
--- a/TagManagerExtended.php
+++ b/TagManagerExtended.php
@@ -15,6 +15,8 @@ class TagManagerExtended extends \Piwik\Plugin
         return array(
             'AssetManager.getStylesheetFiles' => 'getStylesheetFiles',
             'AssetManager.getJavaScriptFiles' => 'getJavaScriptFiles',
+            'TagManager.filterTags' => 'filterTags',
+            'TagManager.filterVariables' => 'filterVariables',
         );
     }
 
@@ -26,5 +28,48 @@ class TagManagerExtended extends \Piwik\Plugin
     public function getJavaScriptFiles(&$files)
     {
         $files[] = "plugins/TagManagerExtended/javascripts/script.js";
+    }
+
+    public function filterTags(&$tags)
+    {
+        $found = false;
+        foreach ($tags as $key => &$tag) {
+            if (in_array($tag->getId(), ['Axeptio', 'CookieYes', 'Cookiebot', 'OneTrust', 'Hotjar', 'GoogleAdsConversion', 'GoogleAnalytics4Event', 'GoogleTag']) && $this->isPartOfTagManagerPlugin($tag)) {
+                $found = true;
+                unset($tags[$key]);
+            }
+        }
+
+        if ($found) {
+            $tags = array_values($tags);
+        }
+    }
+
+    public function filterVariables(&$variables)
+    {
+        $found = false;
+        foreach ($variables as $key => &$variable) {
+            if (in_array($variable->getId(), ['ClickDataAttribute']) && $this->isPartOfTagManagerPlugin($variable)) {
+                $found = true;
+                unset($variables[$key]);
+            }
+        }
+
+        if ($found) {
+            $variables = array_values($variables);
+        }
+    }
+
+    private function isPartOfTagManagerPlugin($object): bool
+    {
+        $classname = get_class($object);
+        $parts = explode('\\', $classname);
+        $pluginName = 'TagManager';
+
+        if (count($parts) >= 4 && $parts[1] === 'Plugins') {
+            $pluginName = $parts[2];
+        }
+
+        return $pluginName === 'TagManager';
     }
 }


### PR DESCRIPTION
Removes conflicting tags and variables from TagManager plugin
Fixes: #PG-4058