### PR TITLE
Add Regex Event Trigger

### DIFF
--- a/Template/Trigger/RegexEventTrigger.php
+++ b/Template/Trigger/RegexEventTrigger.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Matomo - free/libre analytics platform
+ *
+ * @link https://matomo.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\TagManagerExtended\Template\Trigger;
+
+use Piwik\Piwik;
+use Piwik\Settings\FieldConfig;
+use Piwik\Plugins\TagManager\Template\Trigger\BaseTrigger;
+
+class RegexEventTrigger extends BaseTrigger
+{
+    public function getName()
+    {
+        return parent::getName();
+    }
+
+    public function getDescription()
+    {
+        return parent::getDescription();
+    }
+
+    public function getHelp()
+    {
+        return parent::getHelp();
+    }
+
+    public function getCategory()
+    {
+        return self::CATEGORY_OTHERS;
+    }
+
+    public function getIcon()
+    {
+        return 'plugins/TagManagerExtended/images/RegexEventTrigger.svg';
+    }
+
+    public function getParameters()
+    {
+        return [
+            $this->makeSetting('eventNamePattern', '.*', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
+                $field->title = Piwik::translate('TagManagerExtended_RegexEventTriggerPatternTitle');
+                $field->description = Piwik::translate('TagManagerExtended_RegexEventTriggerPatternDescription');
+                $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
+                $field->inlineHelp = Piwik::translate('TagManagerExtended_RegexEventTriggerPatternHelp');
+            }),
+        ];
+    }
+
+    public function getOrder()
+    {
+        return 50;
+    }
+}

--- a/Template/Trigger/RegexEventTrigger.web.js
+++ b/Template/Trigger/RegexEventTrigger.web.js
@@ -1,0 +1,76 @@
+(function () {
+    return function (parameters, TagManager) {
+
+        var pattern = parameters.get('eventNamePattern') || '.*';
+        var regex;
+
+        try {
+            regex = new RegExp(pattern);
+        } catch (e) {
+            // Invalid regex, fall back to match all
+            regex = new RegExp('.*');
+        }
+
+        /**
+         * Check if the dataLayer push matches our regex pattern.
+         * We match any object with an 'event' property that:
+         * 1. Is not a Matomo internal event (mtm.*)
+         * 2. Matches the user-defined regex pattern
+         */
+        function isMatchingEvent(value) {
+            if (!TagManager.utils.isObject(value)) {
+                return false;
+            }
+
+            if (!('event' in value)) {
+                return false;
+            }
+
+            var eventName = value.event;
+
+            // Must be a string
+            if (typeof eventName !== 'string') {
+                return false;
+            }
+
+            // Skip Matomo Tag Manager internal events (they start with 'mtm.')
+            if (eventName.indexOf('mtm.') === 0) {
+                return false;
+            }
+
+            // Test against the regex pattern
+            return regex.test(eventName);
+        }
+
+        // Catch all events that were triggered before the container was fully set up
+        var missedEvents = [];
+        var index = parameters.container.dataLayer.on(function (value) {
+            if (isMatchingEvent(value)) {
+                missedEvents.push(value.event);
+            }
+        });
+
+        this.setUp = function (triggerEvent) {
+            // Stop listening to the initial listener
+            parameters.container.dataLayer.off(index);
+
+            // Replay any missed events
+            for (var i = 0; i < missedEvents.length; i++) {
+                triggerEvent({
+                    event: 'mtm.RegexEvent',
+                    'mtm.customEventMatch': missedEvents[i]
+                });
+            }
+
+            // Listen for all future dataLayer pushes
+            parameters.container.dataLayer.on(function (value) {
+                if (isMatchingEvent(value)) {
+                    triggerEvent({
+                        event: 'mtm.RegexEvent',
+                        'mtm.customEventMatch': value.event
+                    });
+                }
+            });
+        };
+    };
+})();

--- a/images/RegexEventTrigger.svg
+++ b/images/RegexEventTrigger.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path fill="#4caf50" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/>
+  <text x="12" y="16" text-anchor="middle" fill="#4caf50" font-family="monospace" font-size="10" font-weight="bold">.*</text>
+</svg>

--- a/lang/en.json
+++ b/lang/en.json
@@ -205,6 +205,12 @@
         "GoogleUserProvidedDataTagAddressPostalCodeTitle": "address.postal_code",
         "GoogleUserProvidedDataTagAddressPostalCodeDescription": "User post code. Example: 'SO99 9XX'",
         "GoogleUserProvidedDataTagAddressCountryTitle": "address.country",
-        "GoogleUserProvidedDataTagAddressCountryDescription": "User country code. Example: 'UK'. Use 2-letter country codes, per the ISO 3166-1 alpha-2 standard."
+        "GoogleUserProvidedDataTagAddressCountryDescription": "User country code. Example: 'UK'. Use 2-letter country codes, per the ISO 3166-1 alpha-2 standard.",
+        "RegexEventTriggerName": "Regex Event",
+        "RegexEventTriggerDescription": "Fires on custom events matching a regex pattern. Use .* to match all events.",
+        "RegexEventTriggerHelp": "This trigger fires when an event name matches your regex pattern. Use the built-in variable 'Event Name' in your tags to access the name of the event that triggered it.",
+        "RegexEventTriggerPatternTitle": "Event Name Pattern (Regex)",
+        "RegexEventTriggerPatternDescription": "Regular expression pattern to match event names. Use .* to match all events.",
+        "RegexEventTriggerPatternHelp": "Examples: .* (all events), ^form_ (events starting with 'form_'), click|submit (events containing 'click' or 'submit'), ^(purchase|checkout)$ (exactly 'purchase' or 'checkout')"
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a new **Regex Event Trigger** that fires on custom events matching a configurable regex pattern.

## Features

- Configurable regex pattern field (default: `.*` matches all events)
- Skips internal Matomo events (`mtm.*`)
- Replays missed events that occurred before the container fully loaded
- Compatible with the built-in `{{Event Name}}` variable to access the triggering event name

## Example Patterns

| Pattern | Description |
|---------|-------------|
| `.*` | Match all events |
| `^form_` | Events starting with 'form_' |
| `click\|submit` | Events containing 'click' or 'submit' |
| `^(purchase\|checkout)$` | Exactly 'purchase' or 'checkout' |

## Files Added

- `Template/Trigger/RegexEventTrigger.php` - PHP trigger class
- `Template/Trigger/RegexEventTrigger.web.js` - JavaScript implementation
- `images/RegexEventTrigger.svg` - Trigger icon
- Updated `lang/en.json` with translations

## Screenshot

The trigger appears in the "Others" category and provides a text field for entering the regex pattern.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)